### PR TITLE
expose defineFixture method, improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,15 @@
 - [Efate](#efate)
   - [Why use a fixture builder](#why-use-a-fixture-builder)
 - [Installation](#installation)
-- [Usage](#features)
-  - [Creating a fixture](#creating-a-fixture)
-  - [Using the fixture](#using-the-fixture)
+- [Usage](#usage)
+  - [Defining the Fixure](#defining-the-fixure)
+  - [Creating test objects](#creating-test-objects)
   - [Creating Arrays of Fixtures](#creating-arrays-of-fixtures)
   - [Specifying field types and special values](#specifying-field-types-and-special-values)
   - [Provided Type Generators](#provided-type-generators)
 - [Debugging](#debugging)
 - [Extensions](#extensions)
-  - [efate-uuid](#efate-uuid)
-  - [efate-faker](#efate-faker)
+  - [Using an extension](#using-an-extension)
 - [Extending Efate with your own type builder](#extending-efate-with-your-own-type-builder)
   - [Creating the interface](#creating-the-interface)
   - [Create the builder](#create-the-builder)
@@ -29,46 +28,51 @@ Sometimes, when you need to vary the data for a test, it's tempting to create a 
 ```
 npm install efate 
 ```
-Install any extensions you want to use
-- efate-uuid
-- efate-faker
+Install any extensions you want to use, two are currently available from this repo:
+- [efate-uuid](https://github.com/jcteague/efate/tree/master/packages/efate-uuid)
+- [efate-faker](https://github.com/jcteague/efate/tree/master/packages/efate-faker)
 
 ## Usage
 efate provides a typesafe way to define and create your fixtures. You can create the fixtures for each test, each with unique but understandable values.  You can also set specific values of fields of interest for the current test.
 
-### Creating a fixture
-1. Use `createFixtureFactory` to get the function to build fixtures.  This function is used for fixture extension.
-```
-const createFixture = createFixtureFactory() // returns a function that will create fixtures.
-``` 
-2. Use the the function to create the fixture, using the fixture definition to specify the field fields and how the values should be generated.
+There are two phase to fixture usage:
+1. Fixture definition
+2. Object creation
+
+### Defining the Fixure
+Import `defineFixture` to create a standard fixture (without any extensions).
+
 ```typescript
-const userFixture = createFixture<User>(t => {
+import {defineFixture} from "efate";
+```
+Using this function, you can define what fields should be populated and how.
+
+```typescript
+const userFixture = define<User>(t => {
   t.id.asNumber();  // id field will be numberical value that increments as you create user objects
   t.firstName.asString(); 
   t.lastName.asString();
 })
 
+export {userFixture};
 ```
-3. Create the mock object using the fixture, overriding any values that you need to for the test.
-```typescript
-const user = userFixture.create({title: 'myUserName'});
-```
-When you create a this fixture it will create an object that has the `firstName` and `lastName` fields with string values.
+### Creating test objects
 
-### Using the fixture
+Import the test fixture into your file and create the mock object, overriding any values that you need to for the test.
+
 ```javascript
+import {userFixture} from '<your fixtures>';
 // generatate a fixture with system generated values
-const user = UserFixture.create();
-// {firstName: 'firstName1', lastName: 'lastName1'
+const user = userFixture.create();
+// {id: 1, firstName: 'firstName1', lastName: 'lastName1'}
 ```
 As you create more fixtures, the values will vary by incrementing the number for each field
 ```typescript
 // generatate a fixture with system generated values
 const user = userFixture.create();
-// {firstName: 'firstName1', lastName: 'lastName1'
+// {id: 1, firstName: 'firstName1', lastName: 'lastName1'
 const user = userFixture.create();
-// {firstName: 'firstName2', lastName: 'lastName2'
+// {id: 2, firstName: 'firstName2', lastName: 'lastName2'
 ```
 You can override specific fields of the test fixture to test specific cases in your tests and still have complete objects
 
@@ -142,7 +146,8 @@ const userFixture = createFixture<User>(t => {
 ```
 ### Provided Type Generators
 All of the type generators behavior is described in the generated [Spec file](packages/efate/spec.md).
-* **withValues()** uses specified text to generate values
+* **withValues()** 
+ uses specified text to generate values
   ```typescript
   const userFixture = createFixture<{foo:string}>(t => {
     t.foo.withValue('bar')
@@ -208,18 +213,19 @@ There are several extensions available to use with efate that expand the library
 - efate-faker: use the faker library to generate field values
 
 ### Using an extension
+To use an extension, you must use the `defineFixtureFactory` method to include any of the extension you plan to use as part of the `defineFixture` function.
 Extensions have two parts:
 1. An interface that describes usage
 2. A function that handles the implementation for the extension
 
-These are passed to the `createFixtureFactory` function; the interface as a type parameter and the function as a function parameter.
+These are passed to the `defineFixture` function; the interface as a type parameter and the function as a function parameter.
 ```typescript
-import {createFixtureFactory} from 'efate';
+import {defineFixtureFactory} from 'efate';
 import {UUIDExtension, uuidExtension} from 'efate-uuid';
 
-const createFixture = createFixtureFactory<UUIDExtension>(uuidExtension)
+const defineFixture = defineFixtureFactory<UUIDExtension>(uuidExtension)
 
-const userFixture = createFixture(t => {
+const userFixture = defineFixture(t => {
   t.id.asUUID();
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13180,7 +13180,7 @@
       }
     },
     "packages/efate": {
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -13189,7 +13189,7 @@
       }
     },
     "packages/efate-uuid": {
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "efate": "file:../efate",

--- a/packages/efate-faker/efate-faker.tests.ts
+++ b/packages/efate-faker/efate-faker.tests.ts
@@ -1,14 +1,14 @@
 import * as chai from 'chai';
 const expect = chai.expect;
 import { FakerExtension, fakerExtension } from './index';
-import { createFixtureFactory, Field } from 'efate';
+import { defineFixtureFactory, Field } from 'efate';
 interface User {
   name: string;
   title: string;
 }
 describe('efate-faker', () => {
-  const createFixture = createFixtureFactory<FakerExtension>(fakerExtension);
-  const userFixture = createFixture<User>((t) => {
+  const defineFixture = defineFixtureFactory<FakerExtension>(fakerExtension);
+  const userFixture = defineFixture<User>((t) => {
     t.name.faker((f) => f.name.firstName());
     t.title.faker((f, increment) => `${f.name.jobTitle()}${increment}`);
   });

--- a/packages/efate-uuid/uuid.tests.ts
+++ b/packages/efate-uuid/uuid.tests.ts
@@ -1,19 +1,18 @@
 /* tslint:disable: no-unused-expression */
 import * as chai from 'chai';
 const expect = chai.expect;
-import {createFixtureFactory} from 'efate';
-import {UUIDExtension, uuidFieldExtension} from './index';
+import { defineFixtureFactory } from 'efate';
+import { UUIDExtension, uuidFieldExtension } from './index';
 const uuidRegEx = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-describe('asUUID()',  () => {
-    it('should create field with uuid',  () => {
-        const createFixture = createFixtureFactory<UUIDExtension>(uuidFieldExtension)
-        const builder = createFixture<{id: string}>(t => {
-            t.id.asUUID();
-        });
-        const fixture = builder.create();
-        expect(fixture.id).to.exist;
-        expect(fixture.id.match(uuidRegEx)?.length).is.greaterThan(0)
-    })
+describe('asUUID()', () => {
+  it('should create field with uuid', () => {
+    const defineFixture = defineFixtureFactory<UUIDExtension>(uuidFieldExtension);
+    const builder = defineFixture<{ id: string }>((t) => {
+      t.id.asUUID();
+    });
+    const fixture = builder.create();
+    expect(fixture.id).to.exist;
+    expect(fixture.id.match(uuidRegEx)?.length).is.greaterThan(0);
+  });
 });
-

--- a/packages/efate/src/field-type-extenstion.tests.ts
+++ b/packages/efate/src/field-type-extenstion.tests.ts
@@ -1,6 +1,6 @@
 import Field from './field';
 import { expect } from 'chai';
-import { createFixtureFactory } from './fixture-factory';
+import { defineFixtureFactory } from './fixture-factory';
 
 interface FixtureExtension {
   asSSN(startValue: number): () => void;
@@ -28,8 +28,8 @@ interface User {
 }
 describe('when extending with new field generators', () => {
   it('should provide the extended build as an option when creating the fixture', () => {
-    const createFixture = createFixtureFactory<FixtureExtension>(ssnExtension);
-    const userFixture = createFixture<User>((t) => {
+    const defineFixture = defineFixtureFactory<FixtureExtension>(ssnExtension);
+    const userFixture = defineFixture<User>((t) => {
       t.ssn.asSSN(2);
       t.name.asString();
       t.email.asString();
@@ -39,8 +39,8 @@ describe('when extending with new field generators', () => {
     expect(user.name).to.eql('name1');
   });
   it('should allow extension to be optional', () => {
-    const createFixture = createFixtureFactory();
-    const userFixture = createFixture<User>((t) => {
+    const defineFixture = defineFixtureFactory();
+    const userFixture = defineFixture<User>((t) => {
       t.name.asString();
       t.ssn.asString();
       t.email.asString();
@@ -50,11 +50,11 @@ describe('when extending with new field generators', () => {
     expect(user.ssn).eql('ssn1');
   });
   it('should use all extenstions passed to it', () => {
-    const createFixture = createFixtureFactory<CustomEmailDomainExtension & FixtureExtension>(
+    const defineFixture = defineFixtureFactory<CustomEmailDomainExtension & FixtureExtension>(
       ssnExtension,
       customEmailExtension,
     );
-    const userFixture = createFixture<User>((t) => {
+    const userFixture = defineFixture<User>((t) => {
       t.ssn.asSSN(2);
       t.email.emailWithDomain('example.com');
     });

--- a/packages/efate/src/fixture-factory.ts
+++ b/packages/efate/src/fixture-factory.ts
@@ -5,8 +5,15 @@ import { FieldTypeSelector, fieldTypeGenerators } from './property-builders/fiel
 export type DefineFieldsAction<T, TFieldTypeSelector> = (t: {
   [P in keyof T]: TFieldTypeSelector;
 }) => void;
-
 export function createFixtureFactory<TFieldSelectorExtension>(...extensions) {
+  // tslint:disable-next-line:no-console
+  console.warn(
+    'Deprecation Notice! createFixtureFactory has been renamed to defineFixtureFactory.  createFixtureFactory function will be removed in future major versions',
+  );
+  return defineFixtureFactory<TFieldSelectorExtension>(...extensions);
+}
+
+export function defineFixtureFactory<TFieldSelectorExtension>(...extensions) {
   function createFixture<T>(
     defineFields: DefineFieldsAction<T, FieldTypeSelector & TFieldSelectorExtension>,
   ) {
@@ -36,4 +43,7 @@ export function createFixtureFactory<TFieldSelectorExtension>(...extensions) {
     return new Fixture<T>(buildersList);
   }
   return createFixture;
+}
+export function defineFixture<T>(defineFields: DefineFieldsAction<T, FieldTypeSelector>) {
+  return defineFixtureFactory()(defineFields);
 }

--- a/packages/efate/src/fixture.tests.ts
+++ b/packages/efate/src/fixture.tests.ts
@@ -5,7 +5,7 @@ import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 
-import { createFixtureFactory } from './fixture-factory';
+import { createFixtureFactory, defineFixture } from './fixture-factory';
 interface Account {
   userName: string;
   passWord: string;
@@ -20,13 +20,12 @@ interface User {
   account: Account;
 }
 describe('fixture.specs', () => {
-  const createFixture = createFixtureFactory();
-  const accountFixture = createFixture<Account>((a) => {
+  const accountFixture = defineFixture<Account>((a) => {
     a.userName.asString();
     a.passWord.asString();
   });
 
-  const userFixture = createFixture<User>((f) => {
+  const userFixture = defineFixture<User>((f) => {
     f.id?.asNumber();
     f.firstName.asString();
     f.lastName.asString();
@@ -126,14 +125,14 @@ describe('fixture.specs', () => {
 
     describe('withValues()', () => {
       it('increments the specified value for the field value', () => {
-        const fixture = createFixture<User>((t) => t.email.withValue('userEmail')).create() as User;
+        const fixture = defineFixture<User>((t) => t.email.withValue('userEmail')).create() as User;
         expect(fixture.email).to.equal('userEmail1');
       });
     });
 
     describe('asConstant()', () => {
       it('should create fields using a constant value that does not change between instances', () => {
-        const builder = createFixture<User>((t) => t.firstName.asConstant('Bob'));
+        const builder = defineFixture<User>((t) => t.firstName.asConstant('Bob'));
         const fixture1 = builder.create() as User;
         const fixture2 = builder.create() as User;
         expect(fixture1).to.have.property('firstName', 'Bob');
@@ -148,7 +147,7 @@ describe('fixture.specs', () => {
       });
       it('should increment the date instances when specified', () => {
         const today = new Date();
-        const builder = createFixture<{ date: Date }>((t) => t.date.asDate({ incrementDay: true }));
+        const builder = defineFixture<{ date: Date }>((t) => t.date.asDate({ incrementDay: true }));
         const f1 = builder.create();
         const f2 = builder.create();
         expect(f1.date.getDate()).to.be.equal(today.getDate());
@@ -156,7 +155,7 @@ describe('fixture.specs', () => {
       });
     });
     describe('asNumber()', () => {
-      const fb = createFixture<{ id: number }>((t) => t.id.asNumber());
+      const fb = defineFixture<{ id: number }>((t) => t.id.asNumber());
       const f1 = fb.create();
       const f2 = fb.create();
       expect(f1.id).to.equal(1);
@@ -164,32 +163,32 @@ describe('fixture.specs', () => {
     });
     describe('asBoolean()', () => {
       it('should create a boolean field', () => {
-        const fb = createFixture<{ flag: boolean }>((t) => t.flag.asBoolean());
+        const fb = defineFixture<{ flag: boolean }>((t) => t.flag.asBoolean());
         const f = fb.create();
         expect(f.flag).be.a('boolean');
       });
     });
     describe('asEmail()', () => {
       it('should populate field with an email address', () => {
-        const fb = createFixture<{ email: string }>((t) => t.email.asEmail());
+        const fb = defineFixture<{ email: string }>((t) => t.email.asEmail());
         const f = fb.create();
         expect(f.email).to.equal('email1@example.com');
       });
     });
     describe('asArray', () => {
       it('should create an array field on the fixture', () => {
-        const builder = createFixture<{ roles: [] }>((t) => t.roles.asArray());
+        const builder = defineFixture<{ roles: [] }>((t) => t.roles.asArray());
         const f = builder.create();
         expect(f.roles).to.be.an('array');
         expect(f.roles).to.eql(['roles1']);
       });
       it('should create an array with the specified length', () => {
-        const builder = createFixture<{ roles: [] }>((t) => t.roles.asArray({ length: 3 }));
+        const builder = defineFixture<{ roles: [] }>((t) => t.roles.asArray({ length: 3 }));
         const f = builder.create() as { roles: string[] };
         expect(f.roles).to.have.lengthOf(3);
       });
       // it('should create an array of the specified type', () => {
-      //   const builder = createFixture<{roles: []}>(t =>
+      //   const builder = defineFixture<{roles: []}>(t =>
       //     t.roles.asArray({length: 3}));
       //
       //   const f = builder.create() as { roles: any[] };
@@ -199,7 +198,7 @@ describe('fixture.specs', () => {
 
     describe('as()', () => {
       it('should create field using the function passed to it', () => {
-        const builder = createFixture<{ field: string }>((t) => t.field.as((inc) => `field${inc}`));
+        const builder = defineFixture<{ field: string }>((t) => t.field.as((inc) => `field${inc}`));
         const f = builder.create() as { field: string };
         expect(f.field).to.be.equal('field1');
       });
@@ -208,12 +207,12 @@ describe('fixture.specs', () => {
     describe('pickFrom', () => {
       it('should pick from one of the provided values to populate the field', () => {
         const options = ['a', 'b', 'c', 'd'];
-        const builder = createFixture<{ prop: string }>((t) => t.prop.pickFrom(options));
+        const builder = defineFixture<{ prop: string }>((t) => t.prop.pickFrom(options));
         const f = builder.create();
         expect(options).to.include(f.prop);
       });
       it('should throw an error if options are not provided', () => {
-        const f = createFixture<{ prop: string }>((t) => t.prop.pickFrom([]));
+        const f = defineFixture<{ prop: string }>((t) => t.prop.pickFrom([]));
         expect(() => f.create()).to.throw();
       });
     });
@@ -224,11 +223,11 @@ describe('fixture.specs', () => {
           b: string;
         }
 
-        const innerBuilder = createFixture<InnerObj>((t) => {
+        const innerBuilder = defineFixture<InnerObj>((t) => {
           t.a.asString();
           t.b.asString();
         });
-        const outerBuilder = createFixture<{ c: InnerObj }>((t) => t.c.fromFixture(innerBuilder));
+        const outerBuilder = defineFixture<{ c: InnerObj }>((t) => t.c.fromFixture(innerBuilder));
         const fixture = outerBuilder.create();
         expect(fixture).to.have.property('c');
         expect(fixture.c).to.eql({ a: 'a1', b: 'b1' });
@@ -239,11 +238,11 @@ describe('fixture.specs', () => {
           b: string;
         }
 
-        const innerBuilder = createFixture<InnerObj>((t) => {
+        const innerBuilder = defineFixture<InnerObj>((t) => {
           t.a.asString();
           t.b.asString();
         });
-        const outerBuilder = createFixture<{ c: InnerObj }>((t) => t.c.fromFixture(innerBuilder));
+        const outerBuilder = defineFixture<{ c: InnerObj }>((t) => t.c.fromFixture(innerBuilder));
         const fixture = outerBuilder.create({ c: { a: 'd1', b: 'e1' } });
         expect(fixture).to.have.property('c');
         expect(fixture.c).to.eql({ a: 'd1', b: 'e1' });
@@ -256,11 +255,11 @@ describe('fixture.specs', () => {
           b: string;
         }
 
-        const innerFixture = createFixture<InnerObj>((t) => {
+        const innerFixture = defineFixture<InnerObj>((t) => {
           t.a.asString();
           t.b.asString();
         });
-        const outerFixture = createFixture<{ c: InnerObj }>((t) =>
+        const outerFixture = defineFixture<{ c: InnerObj }>((t) =>
           t.c.arrayOfFixture({ fixture: innerFixture }),
         );
         const fixture = outerFixture.create();
@@ -278,7 +277,7 @@ describe('fixture.specs', () => {
           fullName: string;
         }
 
-        const userGenerator = createFixture<Names>((t) => {
+        const userGenerator = defineFixture<Names>((t) => {
           t.firstName.firstName();
           t.lastName.lastName();
           t.fullName.fullName();
@@ -291,13 +290,13 @@ describe('fixture.specs', () => {
     });
     describe('asLoremIpsum()', () => {
       it('should generate the lorem ipusm text', () => {
-        const builder = createFixture<{ lorem: string }>((t) => t.lorem.asLoremIpsum());
+        const builder = defineFixture<{ lorem: string }>((t) => t.lorem.asLoremIpsum());
         const f = builder.create() as { lorem: string };
         // console.log(f);
         expect(f.lorem.length > 10).to.be.true;
       });
       it('should make text longer than the min', () => {
-        const builder = createFixture<{ lorem: string }>((t) =>
+        const builder = defineFixture<{ lorem: string }>((t) =>
           t.lorem.asLoremIpsum({ minLength: 20, maxLength: 50 }),
         );
         const f = builder.create() as { lorem: string };

--- a/packages/efate/src/index.ts
+++ b/packages/efate/src/index.ts
@@ -1,7 +1,7 @@
 import Fixture from './fixture';
 import { BuilderReturnFunction } from './types';
 import Field from './field';
-import { createFixtureFactory } from './fixture-factory';
+import { defineFixtureFactory, defineFixture, createFixtureFactory } from './fixture-factory';
 import asArrayBuilder from './property-builders/array-field-builder';
 import asNumberBuilder from './property-builders/number-field-builder';
 import asBooleanBuilder from './property-builders/boolean-field-builder';
@@ -27,4 +27,4 @@ const propertyBuilders = {
 import { DateBuilderOptions, LoremIpsumOptions } from './types';
 
 export default Fixture;
-export { BuilderReturnFunction, Field, createFixtureFactory };
+export { BuilderReturnFunction, Field, createFixtureFactory, defineFixtureFactory, defineFixture };


### PR DESCRIPTION
- exposes a `defineFixture` function so that you only need to use the factory when using extensions.
- `createFixture` renamed to `defineFixture` to have better delineation between fixture definition and creation.
-  `createFixtureFactory` deprecated 