### PR TITLE
properly applying overrides for array types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@types/chai": "^4.1.4",
+        "@types/lodash.mergewith": "^4.6.9",
         "@types/mocha": "^5.2.5",
         "@types/sinon": "^5.0.1",
         "@types/sinon-chai": "^3.2.0",
@@ -3073,6 +3074,15 @@
       "version": "4.6.7",
       "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
       "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.mergewith": {
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
+      "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
@@ -9229,6 +9239,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+    },
     "node_modules/log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -14725,7 +14740,8 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "lodash.merge": "^4.6.2"
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2"
       },
       "devDependencies": {
         "@types/debug": "^4.1.8",
@@ -17134,6 +17150,15 @@
         "@types/lodash": "*"
       }
     },
+    "@types/lodash.mergewith": {
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
+      "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -18967,7 +18992,8 @@
         "@types/debug": "^4.1.8",
         "@types/lodash.merge": "^4.6.7",
         "debug": "^4.1.1",
-        "lodash.merge": "^4.6.2"
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2"
       },
       "dependencies": {
         "debug": {
@@ -21854,6 +21880,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",
+    "@types/lodash.mergewith": "^4.6.9",
     "@types/mocha": "^5.2.5",
     "@types/sinon": "^5.0.1",
     "@types/sinon-chai": "^3.2.0",

--- a/packages/efate/package.json
+++ b/packages/efate/package.json
@@ -35,7 +35,8 @@
   "homepage": "https://github.com/jcteague/efate#efate",
   "dependencies": {
     "debug": "^4.1.1",
-    "lodash.merge": "^4.6.2"
+    "lodash.merge": "^4.6.2",
+    "lodash.mergewith": "^4.6.2"
   },
   "files": [
     "dist/**/*"

--- a/packages/efate/src/fixture.tests.ts
+++ b/packages/efate/src/fixture.tests.ts
@@ -112,6 +112,26 @@ describe('fixture.specs', () => {
       expect(fixture.account.passWord).to.contain('passWord');
       expect(fixture.account.userName).to.equal('user name overridden');
     });
+    it('should allow users to override array of fixtures', () => {
+      interface InnerObj {
+        a: string;
+      }
+      interface OuterObj {
+        x:string;
+        arrayOfInner: InnerObj[];
+      }
+      const innerFixture = defineFixture<InnerObj>((t) => {
+        t.a.asString();
+      });
+      const outerFixture = defineFixture<OuterObj>((t) => {
+        t.x.asString();
+        t.arrayOfInner.arrayOfFixture({ fixture: innerFixture });
+      });
+      const fixture = outerFixture.create({
+        arrayOfInner: innerFixture.createArrayWith(1),
+      });
+      expect(fixture.arrayOfInner).to.have.lengthOf(1);
+    });
   });
 
   describe('extends', () => {

--- a/packages/efate/src/fixture.ts
+++ b/packages/efate/src/fixture.ts
@@ -1,17 +1,23 @@
 import debugGenerator from 'debug';
-import merge from 'lodash.merge';
+import mergeWith from 'lodash.mergewith';
 import type { PartialDeep } from 'type-fest';
 
 import { BuilderGeneratorFunction } from './types';
 import { isFunction } from './utils';
 
-const debug = debugGenerator('efate:fixture-factory');
+const debug = debugGenerator('efate:fixture');
 
 type OverridesFn<T> = (fixture: T) => void;
 type Overrides<T> = PartialDeep<T> | OverridesFn<T>;
 
 type CreateArrayParameterFn<T> = (index: number, create: (overrides?: Overrides<T>) => T) => T;
 type CreateArrayParameter<T> = PartialDeep<T> | Array<PartialDeep<T>> | CreateArrayParameterFn<T>;
+
+const mergeOverrides = (objValue: any, newValue: any) => {
+  if (Array.isArray(objValue)) {
+    return newValue;
+  }
+};
 
 export default class Fixture<T> {
   private omittedFields: Set<keyof T> = new Set();
@@ -50,9 +56,10 @@ export default class Fixture<T> {
 
     this.omittedFields.clear();
     this.instanceCount++;
-
+    debug('fixture: %o, overrides: %o', fixture, overrides)
     if (overrides) {
-      isFunction(overrides) ? overrides(fixture) : merge(fixture, overrides);
+      isFunction(overrides) ? overrides(fixture) : mergeWith(fixture, overrides, mergeOverrides);
+      debug('fixture after applying overrides: %o',  fixture)
     }
 
     return fixture;


### PR DESCRIPTION
fixes #125 

using `lodash.mergeWith` fn to override behavior of array overrides